### PR TITLE
Fix: prompt for rejection reason before saving Rejected status

### DIFF
--- a/client/src/components/DetailHeader.tsx
+++ b/client/src/components/DetailHeader.tsx
@@ -91,7 +91,7 @@ export function DetailHeader({
             }}
             disabled={isUpdating}
           >
-            <SelectTrigger className="w-[200px]">
+            <SelectTrigger className="w-[200px]" aria-label="Status">
               <SelectValue>
                 <StatusBadge status={application.status} />
               </SelectValue>

--- a/client/src/components/RejectionReasonDialog.tsx
+++ b/client/src/components/RejectionReasonDialog.tsx
@@ -1,0 +1,118 @@
+// Shown when the user selects "Rejected" from the status dropdown.
+// Collects reason (required) and notes before the PATCH is sent, because
+// the API enforces that rejection.reason is present in the same request
+// as the status change — it cannot be added in a separate call.
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { REJECTION_REASONS } from "@/types";
+import type { RejectionReason } from "@/types";
+
+interface RejectionReasonDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (data: { reason: RejectionReason; notes: string }) => Promise<void>;
+  isLoading: boolean;
+}
+
+export function RejectionReasonDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isLoading,
+}: RejectionReasonDialogProps) {
+  const [reason, setReason] = useState<RejectionReason | "">("");
+  const [notes, setNotes] = useState("");
+
+  function handleClose(isOpen: boolean) {
+    if (!isOpen) {
+      setReason("");
+      setNotes("");
+    }
+    onOpenChange(isOpen);
+  }
+
+  async function handleConfirm() {
+    if (!reason) return;
+    await onConfirm({ reason, notes });
+    setReason("");
+    setNotes("");
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Mark as Rejected</DialogTitle>
+          <DialogDescription>
+            Please provide a reason for the rejection before saving.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="dialog-rejection-reason">
+              Reason <span className="text-destructive">*</span>
+            </Label>
+            <Select
+              value={reason}
+              onValueChange={(val) => setReason((val ?? "") as RejectionReason | "")}
+            >
+              <SelectTrigger id="dialog-rejection-reason">
+                <SelectValue placeholder="Select reason..." />
+              </SelectTrigger>
+              <SelectContent>
+                {REJECTION_REASONS.map((r) => (
+                  <SelectItem key={r} value={r}>
+                    {r}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="dialog-rejection-notes">Notes</Label>
+            <Textarea
+              id="dialog-rejection-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+              placeholder="Additional details..."
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleClose(false)}
+            disabled={isLoading}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={!reason || isLoading}>
+            {isLoading ? "Saving..." : "Confirm Rejection"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/RejectionReasonDialog.tsx
+++ b/client/src/components/RejectionReasonDialog.tsx
@@ -51,8 +51,8 @@ export function RejectionReasonDialog({
   async function handleConfirm() {
     if (!reason) return;
     await onConfirm({ reason, notes });
-    setReason("");
-    setNotes("");
+    // State resets via handleClose when the dialog closes on success.
+    // On failure the parent leaves the dialog open, preserving the user's input.
   }
 
   return (

--- a/client/src/pages/ApplicationDetailPage.test.tsx
+++ b/client/src/pages/ApplicationDetailPage.test.tsx
@@ -375,6 +375,42 @@ describe("ApplicationDetailPage", () => {
     ).toBeDisabled();
   });
 
+  it("sends status and rejection together when confirming rejection", async () => {
+    const user = userEvent.setup();
+    let patchBody: unknown;
+    server.use(
+      http.patch("/api/applications/:id", async ({ request }) => {
+        patchBody = await request.json();
+        return HttpResponse.json({
+          data: { ...mockApplication, status: "Rejected" },
+          error: null,
+        });
+      }),
+    );
+
+    renderDetailPage();
+    await waitFor(() => expect(screen.getByText("Contoso Ltd")).toBeInTheDocument());
+
+    const statusTrigger = screen.getByRole("combobox", { name: /status/i });
+    await user.click(statusTrigger);
+    await user.click(await screen.findByRole("option", { name: "Rejected" }));
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    // Pick a reason from the dialog's combobox
+    const reasonTrigger = screen.getByRole("combobox", { name: /reason/i });
+    await user.click(reasonTrigger);
+    await user.click(await screen.findByRole("option", { name: "Ghosted" }));
+
+    await user.click(screen.getByRole("button", { name: /confirm rejection/i }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(patchBody).toMatchObject({
+      status: "Rejected",
+      rejection: { reason: "Ghosted" },
+    });
+  });
+
   // --- Activity Log tests ---
 
   it("displays activity log section with history events", async () => {

--- a/client/src/pages/ApplicationDetailPage.test.tsx
+++ b/client/src/pages/ApplicationDetailPage.test.tsx
@@ -303,6 +303,78 @@ describe("ApplicationDetailPage", () => {
     expect(screen.getByLabelText(/notes/i)).toBeInTheDocument();
   });
 
+  // --- Rejection reason dialog (status change to Rejected) ---
+
+  it("opens rejection reason dialog when selecting Rejected status", async () => {
+    const user = userEvent.setup();
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Contoso Ltd")).toBeInTheDocument();
+    });
+
+    // Open the status dropdown
+    const statusTrigger = screen.getByRole("combobox", { name: /status/i });
+    await user.click(statusTrigger);
+
+    // Select "Rejected"
+    const rejectedOption = await screen.findByRole("option", { name: "Rejected" });
+    await user.click(rejectedOption);
+
+    // Dialog should appear asking for rejection reason
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/mark as rejected/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/reason/i)).toBeInTheDocument();
+  });
+
+  it("closes rejection dialog on cancel without saving", async () => {
+    const user = userEvent.setup();
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Contoso Ltd")).toBeInTheDocument();
+    });
+
+    const statusTrigger = screen.getByRole("combobox", { name: /status/i });
+    await user.click(statusTrigger);
+    const rejectedOption = await screen.findByRole("option", { name: "Rejected" });
+    await user.click(rejectedOption);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("confirm button is disabled until a reason is selected", async () => {
+    const user = userEvent.setup();
+    renderDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Contoso Ltd")).toBeInTheDocument();
+    });
+
+    const statusTrigger = screen.getByRole("combobox", { name: /status/i });
+    await user.click(statusTrigger);
+    const rejectedOption = await screen.findByRole("option", { name: "Rejected" });
+    await user.click(rejectedOption);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /confirm rejection/i }),
+    ).toBeDisabled();
+  });
+
   // --- Activity Log tests ---
 
   it("displays activity log section with history events", async () => {

--- a/client/src/pages/ApplicationDetailPage.tsx
+++ b/client/src/pages/ApplicationDetailPage.tsx
@@ -9,6 +9,7 @@ import { RejectionSection } from "@/components/RejectionSection";
 import { FileSection } from "@/components/FileSection";
 import { InterviewList } from "@/components/InterviewList";
 import { InterviewModal } from "@/components/InterviewModal";
+import { RejectionReasonDialog } from "@/components/RejectionReasonDialog";
 import { ActivityLog } from "@/components/ActivityLog";
 import { useApplication } from "@/hooks/useApplication";
 import {
@@ -49,6 +50,9 @@ export function ApplicationDetailPage() {
   const { download } = useDownloadFile();
   const { deleteFile } = useDeleteFile();
 
+  // Rejection reason dialog state
+  const [rejectionDialogOpen, setRejectionDialogOpen] = useState(false);
+
   // Interview modal state
   const [interviewModalOpen, setInterviewModalOpen] = useState(false);
   const [editingInterview, setEditingInterview] = useState<
@@ -67,9 +71,35 @@ export function ApplicationDetailPage() {
 
   const handleStatusChange = async (status: ApplicationStatus) => {
     if (!application) return;
+    // The API requires rejection.reason in the same PATCH body when status is
+    // "Rejected", so we intercept here and collect it via a dialog first.
+    if (status === "Rejected") {
+      setRejectionDialogOpen(true);
+      return;
+    }
     const res = await update(application.id, { status });
     if (res.data) {
       toast.success(`Status updated to ${status}`);
+      refetch();
+    } else {
+      toast.error(formatApiError(res.error, "Failed to update status"));
+    }
+  };
+
+  const handleRejectionConfirm = async (rejection: {
+    reason: RejectionReason;
+    notes: string;
+  }) => {
+    if (!application) return;
+    // Send status and rejection together — the API validates that reason is
+    // present whenever status is "Rejected" and rejects partial updates.
+    const res = await update(application.id, {
+      status: "Rejected",
+      rejection,
+    });
+    if (res.data) {
+      toast.success("Status updated to Rejected");
+      setRejectionDialogOpen(false);
       refetch();
     } else {
       toast.error(formatApiError(res.error, "Failed to update status"));
@@ -293,6 +323,13 @@ export function ApplicationDetailPage() {
         onSubmit={handleInterviewSubmit}
         isLoading={editingInterview ? isUpdatingInterview : isAddingInterview}
         interview={editingInterview}
+      />
+
+      <RejectionReasonDialog
+        open={rejectionDialogOpen}
+        onOpenChange={setRejectionDialogOpen}
+        onConfirm={handleRejectionConfirm}
+        isLoading={isUpdating}
       />
     </div>
   );


### PR DESCRIPTION
When changing status to "Rejected", the API requires rejection.reason
in the same PATCH body. Previously, the status was sent alone, causing
the request to fail silently. Now a dialog intercepts the "Rejected"
selection, collects the reason and optional notes, and sends both in a
single PATCH call.

- Add RejectionReasonDialog component (modal with reason select + notes)
- Intercept "Rejected" in handleStatusChange to open the dialog
- Add handleRejectionConfirm that PATCHes { status, rejection } together
- Add aria-label="Status" to DetailHeader SelectTrigger for accessibility
- Add 3 new tests covering dialog open, cancel, and disabled confirm

https://claude.ai/code/session_01KNAJ1XHhZ8jQ991VR3En3E