### PR TITLE
fix: add SWA navigationFallback to resolve 404 on page refresh

### DIFF
--- a/client/public/staticwebapp.config.json
+++ b/client/public/staticwebapp.config.json
@@ -1,0 +1,17 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/api/*",
+      "/*.js",
+      "/*.css",
+      "/*.svg",
+      "/*.png",
+      "/*.ico",
+      "/*.woff",
+      "/*.woff2",
+      "/*.ttf",
+      "/*.map"
+    ]
+  }
+}


### PR DESCRIPTION
Azure Static Web Apps returned 404 for any deep route (e.g. /dashboard,
/applications/:id) on hard refresh because no physical file existed at
those paths. Adding staticwebapp.config.json with a navigationFallback
rule instructs SWA to serve index.html for unknown routes, letting React
Router handle client-side navigation. Fixes issue #3.

https://claude.ai/code/session_01HLmjWnsdWnMFL642vX6nwY