### PR TITLE
fix(dashboard): default date range start to Jan 1 of current year

### DIFF
--- a/client/src/hooks/useStats.ts
+++ b/client/src/hooks/useStats.ts
@@ -13,7 +13,7 @@ interface UseStatsReturn {
 
 function defaultDateRange(): { from: string; to: string } {
   const now = new Date();
-  const from = new Date(now.getFullYear(), now.getMonth(), 1)
+  const from = new Date(now.getFullYear(), 0, 1)
     .toISOString()
     .slice(0, 10);
   const to = now.toISOString().slice(0, 10);


### PR DESCRIPTION
Sets the go-live date (Jan 1) as the default 'from' date for the
dashboard stats filter instead of the 1st of the current month.

https://claude.ai/code/session_01YZnsejskRPpqvcY9XAPeQq